### PR TITLE
feat: esqueleto de Funcionarios

### DIFF
--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/CriarFuncionarioDTO.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/CriarFuncionarioDTO.java
@@ -1,0 +1,10 @@
+package com.agt.desafio_tecnico.dominio.funcionarios.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CriarFuncionarioDTO(
+        @NotBlank(message = "O nome do funcionário não pode estar vazio")
+        String nome,
+        String cnh
+) {
+}

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/VisualizarFuncionarioDTO.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/VisualizarFuncionarioDTO.java
@@ -1,0 +1,27 @@
+package com.agt.desafio_tecnico.dominio.funcionarios.dto;
+
+import com.agt.desafio_tecnico.dominio.funcionarios.modelo.Funcionario;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record VisualizarFuncionarioDTO(
+        UUID id,
+        String nome,
+        String cnh,
+        @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+        LocalDateTime criadoEm,
+        @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
+        LocalDateTime atualizadoEm
+) {
+    public static VisualizarFuncionarioDTO fromEntity(Funcionario funcionario) {
+        return new VisualizarFuncionarioDTO(
+                funcionario.getId(),
+                funcionario.getNome(),
+                funcionario.getCnh(),
+                funcionario.getCriadoEm(),
+                funcionario.getAtualizadoEm() == null ? null : funcionario.getAtualizadoEm()
+        );
+    }
+}

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/modelo/Funcionario.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/modelo/Funcionario.java
@@ -1,0 +1,38 @@
+package com.agt.desafio_tecnico.dominio.funcionarios.modelo;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@EqualsAndHashCode(of = "id")
+public class Funcionario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+    @Column(nullable = false)
+    private String nome;
+    @Column(unique = true)
+    private String cnh;
+    private LocalDateTime criadoEm;
+    private LocalDateTime atualizadoEm;
+
+    @PrePersist
+    public void prePersist() {
+        this.criadoEm = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.atualizadoEm = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/repositorio/FuncionarioRepositorio.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/repositorio/FuncionarioRepositorio.java
@@ -1,0 +1,11 @@
+package com.agt.desafio_tecnico.dominio.funcionarios.repositorio;
+
+import com.agt.desafio_tecnico.dominio.funcionarios.modelo.Funcionario;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FuncionarioRepositorio extends JpaRepository<Funcionario, UUID> {
+}

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/servico/FuncionarioService.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/servico/FuncionarioService.java
@@ -1,0 +1,14 @@
+package com.agt.desafio_tecnico.dominio.funcionarios.servico;
+
+import com.agt.desafio_tecnico.dominio.funcionarios.repositorio.FuncionarioRepositorio;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FuncionarioService {
+    private final FuncionarioRepositorio funcionarioRepositorio;
+
+}


### PR DESCRIPTION
This pull request introduces a new domain model for managing "Funcionarios" (employees) in the system. It includes the creation of DTOs, the entity model, a repository interface, and a service layer. These changes lay the groundwork for CRUD operations and data persistence for the `Funcionario` entity.

### Domain Model and Entity Setup:
* Created the `Funcionario` entity with fields for `id`, `nome`, `cnh`, `criadoEm`, and `atualizadoEm`. Includes JPA annotations for persistence and lifecycle callbacks to set timestamps automatically. (`src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/modelo/Funcionario.java`)

### Data Transfer Objects (DTOs):
* Added `CriarFuncionarioDTO` for creating new `Funcionario` records, with validation for the `nome` field. (`src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/CriarFuncionarioDTO.java`)
* Added `VisualizarFuncionarioDTO` for viewing `Funcionario` details, including a static method to map from the entity. (`src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/dto/VisualizarFuncionarioDTO.java`)

### Repository Layer:
* Created `FuncionarioRepositorio`, a Spring Data JPA repository for `Funcionario` entity persistence and retrieval. (`src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/repositorio/FuncionarioRepositorio.java`)

### Service Layer:
* Introduced `FuncionarioService` to encapsulate business logic for the `Funcionario` domain. Currently, it includes dependency injection for the repository. (`src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/servico/FuncionarioService.java`)