### PR TITLE
Feature implementando esqueleto funcionario

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/modelo/Funcionario.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/modelo/Funcionario.java
@@ -25,10 +25,12 @@ public class Funcionario {
     private String cnh;
     private LocalDateTime criadoEm;
     private LocalDateTime atualizadoEm;
+    private boolean ativo;
 
     @PrePersist
     public void prePersist() {
         this.criadoEm = LocalDateTime.now();
+        this.ativo = true;
     }
 
     @PreUpdate

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/repositorio/FuncionarioRepositorio.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/repositorio/FuncionarioRepositorio.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface FuncionarioRepositorio extends JpaRepository<Funcionario, UUID> {
+
 }

--- a/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/servico/FuncionarioService.java
+++ b/src/main/java/com/agt/desafio_tecnico/dominio/funcionarios/servico/FuncionarioService.java
@@ -1,9 +1,17 @@
 package com.agt.desafio_tecnico.dominio.funcionarios.servico;
 
+import com.agt.desafio_tecnico.dominio.funcionarios.dto.CriarFuncionarioDTO;
+import com.agt.desafio_tecnico.dominio.funcionarios.dto.VisualizarFuncionarioDTO;
+import com.agt.desafio_tecnico.dominio.funcionarios.modelo.Funcionario;
 import com.agt.desafio_tecnico.dominio.funcionarios.repositorio.FuncionarioRepositorio;
+import com.agt.desafio_tecnico.excecoes.RecursoNaoEncontradoException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -11,4 +19,30 @@ import org.springframework.stereotype.Service;
 public class FuncionarioService {
     private final FuncionarioRepositorio funcionarioRepositorio;
 
+    @Transactional
+    public VisualizarFuncionarioDTO criarFuncionario(CriarFuncionarioDTO dto) {
+        Funcionario funcionario = Funcionario.builder()
+                .nome(dto.nome())
+                .cnh(dto.cnh())
+                .build();
+
+        funcionarioRepositorio.save(funcionario);
+
+        return VisualizarFuncionarioDTO.fromEntity(funcionario);
+    }
+
+    @Transactional(readOnly = true)
+    public VisualizarFuncionarioDTO visualizarFuncionarioPorId(UUID id) {
+        return funcionarioRepositorio.findById(id)
+                .map(VisualizarFuncionarioDTO::fromEntity)
+                .orElseThrow(() -> new RecursoNaoEncontradoException("Funcionário não encontrado com o ID: " + id));
+    }
+
+    @Transactional
+    public List<VisualizarFuncionarioDTO> listarFuncionarios() {
+        List<Funcionario> funcionarios = funcionarioRepositorio.findAll();
+        return funcionarios.stream()
+                .map(VisualizarFuncionarioDTO::fromEntity)
+                .toList();
+    }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance functionality, improve code maintainability, and add new features to the project. The most significant updates include adding OpenAPI support, introducing a new `ativo` field in the `Funcionario` model, and implementing new service methods for creating, retrieving, and listing `Funcionario` entities.

### Dependency Management:
* Added the `springdoc-openapi-starter-webmvc-ui` dependency to the `pom.xml` file to enable OpenAPI documentation generation for the project.
* Updated the annotation processor configuration in `pom.xml` to include the `${lombok.version}` property for better version management of Lombok.

### Model Enhancements:
* Added a new `ativo` field to the `Funcionario` model to track whether a `Funcionario` is active. The field is initialized to `true` during entity persistence using the `@PrePersist` lifecycle callback.

### Service Layer Improvements:
* Introduced three new methods in `FuncionarioService`:
  - `criarFuncionario`: Handles the creation of a new `Funcionario` entity.
  - `visualizarFuncionarioPorId`: Retrieves a `Funcionario` by its ID, throwing an exception if not found.
  - [`listarFuncionarios`](diffhunk://#diff-d3a66434c0ecfbe68cd75f226d28bdf95e51da2e67c6d0bfb64b4a2e94f00855R3-R47): Lists all `Funcionario` entities, converting them to DTOs for response.

### Repository Updates:
* Added a minor formatting change in `FuncionarioRepositorio` to improve code readability.